### PR TITLE
Fix value.name bug in GetFieldValue

### DIFF
--- a/types/project-v2.psm1
+++ b/types/project-v2.psm1
@@ -155,12 +155,12 @@ class ProjectItem: GraphQLObjectBase {
         }
 
         $value = $this.fieldValues | Where-Object { $_.fieldId -eq $field.id }
-
         if (-not $value) {
             return $null
         }
 
-        return $value.name ?? $value.value
+        $result = if ($value.name) { $value.name } else { $value.value }
+        return $result
     }
 
     [bool]TrySetFieldValue(


### PR DESCRIPTION
This PR fixes a bug in `GetFieldValue` where `$value.name` didn't fall through nullish coalescing when it's an empty string.